### PR TITLE
Reduce the experiment size for overnight benchmarking.

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -7,8 +7,8 @@ benchmark_suites:
         command: " harness.lua %(benchmark)s %(iterations)s "
         max_invocation_time: 600 # seconds per vm invocation
         min_iteration_time: 200 # miliseconds per iteration
-        invocations: 10 # the number of process executions
-        iterations: 30 # the number of in-process iterations
+        invocations: 5 # the number of process executions
+        iterations: 10 # the number of in-process iterations
         cores: [ "default" ]
         location: awfy/Lua
         benchmarks: &BENCHMARKS


### PR DESCRIPTION
Before we were doing 10 proc. execs and 30 in-proc iters. This was taking about 10 hours -- well into our work day when CI will be happening.

This reduces the experiment to 5 proc. execs and 10 in-proc iters, which should take just under 2.5 hours.

At present we start benchmarking at 2am, so benchmarking should finish about 4:30am.

This should also stop some benchmarks exceeding the per-process execution timeout.