### PR TITLE
Remove CIs from our rough benchmark report.

### DIFF
--- a/reporter/Cargo.toml
+++ b/reporter/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.38"
 plotters = "0.3.6"
-stats-ci = "0.1.1"
 walkdir = "2.5.0"

--- a/reporter/src/main.rs
+++ b/reporter/src/main.rs
@@ -46,8 +46,8 @@ fn process_file(
         // This benchmark wasn't run at this time.
         return;
     }
-    // Collect execution times on a per-vm basis.
-    let mut exec_times: HashMap<String, Vec<f64>> = HashMap::new();
+    // Collect in-process iteration times on a per-vm basis.
+    let mut data: HashMap<String, Vec<f64>> = HashMap::new();
     for row_idx in 0..rf.len() {
         let row = rf.row(row_idx);
         debug_assert!(row[rf.col_idx("benchmark")] == bm_name);
@@ -56,8 +56,7 @@ fn process_file(
 
         debug_assert!(row[rf.col_idx("unit")] == "ms");
         let time = row[rf.col_idx("value")].parse::<f64>().unwrap().round();
-        exec_times
-            .entry(vm_name.to_string())
+        data.entry(vm_name.to_string())
             .or_default()
             .push(time as f64);
     }
@@ -69,8 +68,8 @@ fn process_file(
         .unwrap();
     // Compute points for the absolute times plot.
     let mut means = HashMap::new();
-    for (vm, exec_times) in &exec_times {
-        let mean = exec_times.iter().sum::<f64>() / (exec_times.len() as f64);
+    for (vm, iter_times) in &data {
+        let mean = iter_times.iter().sum::<f64>() / (iter_times.len() as f64);
         means.insert(vm.to_owned(), mean);
         let line = abs_lines
             .entry(vm.to_string())

--- a/reporter/src/plot.rs
+++ b/reporter/src/plot.rs
@@ -1,6 +1,7 @@
 //! Helper type/routines for generating plots.
 
 use chrono::{DateTime, Duration, Local, NaiveDateTime};
+use core::f64;
 use plotters::prelude::*;
 use plotters::style::{FontDesc, FontFamily};
 use std::{collections::HashMap, ops::Range, path::PathBuf};
@@ -9,11 +10,13 @@ pub struct Point {
     /// The X-value.
     x: DateTime<Local>,
     /// The Y-value.
-    y: f64,
+    ///
+    /// None means that at least one benchmark crashed at this time.
+    y: Option<f64>,
 }
 
 impl Point {
-    pub fn new(x: DateTime<Local>, y: f64) -> Self {
+    pub fn new(x: DateTime<Local>, y: Option<f64>) -> Self {
         Self { x, y }
     }
 }
@@ -75,11 +78,13 @@ impl PlotConfig {
 }
 
 /// Find appropriate min/max values for the X and Y axis.
-fn find_plot_extents(lines: &HashMap<String, Line>) -> (Range<DateTime<Local>>, Range<f64>) {
+fn find_plot_extents(
+    lines: &HashMap<String, Line>,
+) -> Result<(Range<DateTime<Local>>, Range<f64>), ()> {
     let mut start_x = NaiveDateTime::MAX.and_local_timezone(Local).unwrap();
     let mut end_x = NaiveDateTime::MIN.and_local_timezone(Local).unwrap();
-    let mut start_y = f64::MAX;
-    let mut end_y = f64::MIN;
+    let mut start_y = None;
+    let mut end_y = None;
 
     for line in lines.values() {
         for x in line.points.iter().map(|p| p.x) {
@@ -91,91 +96,118 @@ fn find_plot_extents(lines: &HashMap<String, Line>) -> (Range<DateTime<Local>>, 
             }
         }
         for y in line.points.iter().map(|p| p.y) {
-            if y <= start_y {
-                start_y = y;
-            }
-            if y >= end_y {
-                end_y = y;
+            if let Some(y) = y {
+                if start_y.is_none() || y <= start_y.unwrap() {
+                    start_y = Some(y);
+                }
+                if end_y.is_none() || y >= end_y.unwrap() {
+                    end_y = Some(y);
+                }
             }
         }
     }
 
-    // Ensure we aren't butted up against the axis.
-    start_x -= Duration::hours(2);
-    end_x += Duration::hours(2);
-    start_y -= start_y * 0.1;
-    end_y += end_y * 0.1;
+    if let Some(mut start_y) = start_y {
+        // Ensure we aren't butted up against the axis.
+        start_x -= Duration::hours(2);
+        end_x += Duration::hours(2);
 
-    assert!(start_x <= end_x);
-    assert!(start_y <= end_y);
-    assert!(start_x != NaiveDateTime::MIN.and_local_timezone(Local).unwrap());
-    assert!(end_x != NaiveDateTime::MAX.and_local_timezone(Local).unwrap());
-    (start_x..end_x, start_y..end_y)
+        start_y -= start_y * 0.1;
+        let mut end_y = end_y.unwrap();
+        end_y += end_y * 0.1;
+
+        assert!(start_x <= end_x);
+        assert!(start_y <= end_y);
+        assert!(start_x != NaiveDateTime::MIN.and_local_timezone(Local).unwrap());
+        assert!(end_x != NaiveDateTime::MAX.and_local_timezone(Local).unwrap());
+        Ok((start_x..end_x, start_y..end_y))
+    } else {
+        Err(())
+    }
 }
 
-/// Plot some data into a SVG file.
+/// Plot some data into an image file.
 ///
 /// If we are plotting more than one line, then they are assumed to contain the same x-values.
 ///
-/// Returns the last (rightmost) X value.
-pub fn plot(config: &PlotConfig) -> DateTime<Local> {
-    let (x_extent, y_extent) = find_plot_extents(&config.lines);
+/// Returns the last (rightmost) X value (if known).
+pub fn plot(config: &PlotConfig) -> Result<DateTime<Local>, ()> {
+    if let Ok((x_extent, y_extent)) = find_plot_extents(&config.lines) {
+        let drawing = BitMapBackend::new(&config.output_path, (850, 600)).into_drawing_area();
+        drawing.fill(&WHITE).unwrap();
 
-    let drawing = BitMapBackend::new(&config.output_path, (850, 600)).into_drawing_area();
-    drawing.fill(&WHITE).unwrap();
+        let mut chart = ChartBuilder::on(&drawing)
+            .caption(&config.title, ("sans-serif", 20))
+            .set_label_area_size(LabelAreaPosition::Left, 50)
+            .set_label_area_size(LabelAreaPosition::Bottom, 50)
+            .x_label_area_size(40)
+            .y_label_area_size(70)
+            .margin(20)
+            .build_cartesian_2d(x_extent, y_extent)
+            .unwrap();
 
-    let mut chart = ChartBuilder::on(&drawing)
-        .caption(&config.title, ("sans-serif", 20))
-        .set_label_area_size(LabelAreaPosition::Left, 50)
-        .set_label_area_size(LabelAreaPosition::Bottom, 50)
-        .x_label_area_size(40)
-        .y_label_area_size(70)
-        .margin(20)
-        .build_cartesian_2d(x_extent, y_extent)
-        .unwrap();
+        // Make axis labels easier to read.
+        let desc_style =
+            FontDesc::new(FontFamily::SansSerif, 18.0, "Regular".into()).into_text_style(&drawing);
 
-    // Make axis labels easier to read.
-    let desc_style =
-        FontDesc::new(FontFamily::SansSerif, 18.0, "Regular".into()).into_text_style(&drawing);
+        chart
+            .configure_mesh()
+            .x_desc(&config.x_axis_label)
+            .y_desc(&config.y_axis_label)
+            .axis_desc_style(desc_style)
+            .x_label_formatter(&|x| x.format("%Y-%m-%d").to_string())
+            .draw()
+            .unwrap();
 
-    chart
-        .configure_mesh()
-        .x_desc(&config.x_axis_label)
-        .y_desc(&config.y_axis_label)
-        .axis_desc_style(desc_style)
-        .x_label_formatter(&|x| x.format("%Y-%m-%d").to_string())
-        .draw()
-        .unwrap();
+        let mut last_x = None;
+        for (vm, line) in &config.lines {
+            let colour = line.colour;
+            // Sort the points so that the line doesn't zig-zag back and forth across the X-axis.
+            let mut sorted_points = line.points.iter().map(|p| (p.x, p.y)).collect::<Vec<_>>();
+            sorted_points.sort_by(|p1, p2| p1.0.partial_cmp(&p2.0).unwrap());
 
-    let mut last_x = None;
-    for (vm, line) in &config.lines {
-        let colour = line.colour;
-        // Sort the points so that the line doesn't zig-zag back and forth across the X-axis.
-        let mut sorted_points = line.points.iter().map(|p| (p.x, p.y)).collect::<Vec<_>>();
-        sorted_points.sort_by(|p1, p2| p1.0.partial_cmp(&p2.0).unwrap());
+            // Cache the rightmost X value.
+            if last_x.is_none() {
+                last_x = Some(sorted_points.last().unwrap().0);
+            }
 
-        // Cache the rightmost X value.
-        if last_x.is_none() {
-            last_x = Some(sorted_points.last().unwrap().0);
+            // Draw points where no benchmarks crashed.
+            let ok_points = sorted_points
+                .iter()
+                .filter(|(_, y)| y.is_some())
+                .map(|(x, y)| (x.clone(), y.unwrap()));
+            chart
+                .draw_series(LineSeries::new(ok_points, colour).point_size(2))
+                .unwrap()
+                .label(vm)
+                .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colour));
+
+            // Draw a cross at y=0 where benchmarks crashed.
+            let crash_points = sorted_points
+                .iter()
+                .filter(|(_, y)| y.is_none())
+                .map(|(x, _)| (x.clone(), 0.0));
+            let crash_series =
+                PointSeries::of_element(crash_points, 2, colour, &|c, s, st| Cross::new(c, s, st));
+            chart
+                .draw_series(crash_series)
+                .unwrap()
+                .label(vm)
+                .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colour));
         }
 
-        // Draw line.
+        // Draw on the legend.
         chart
-            .draw_series(LineSeries::new(sorted_points, colour).point_size(2))
-            .unwrap()
-            .label(vm)
-            .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colour));
+            .configure_series_labels()
+            .border_style(BLACK)
+            .background_style(WHITE.mix(0.8))
+            .draw()
+            .unwrap();
+
+        drawing.present().unwrap();
+
+        Ok(last_x.unwrap())
+    } else {
+        Err(())
     }
-
-    // Draw on the legend.
-    chart
-        .configure_series_labels()
-        .border_style(BLACK)
-        .background_style(WHITE.mix(0.8))
-        .draw()
-        .unwrap();
-
-    drawing.present().unwrap();
-
-    last_x.unwrap()
 }

--- a/reporter/src/plot.rs
+++ b/reporter/src/plot.rs
@@ -10,13 +10,11 @@ pub struct Point {
     x: DateTime<Local>,
     /// The Y-value.
     y: f64,
-    /// The error bar for the Y-value.
-    y_err: (f64, f64),
 }
 
 impl Point {
-    pub fn new(x: DateTime<Local>, y: f64, y_err: (f64, f64)) -> Self {
-        Self { x, y, y_err }
+    pub fn new(x: DateTime<Local>, y: f64) -> Self {
+        Self { x, y }
     }
 }
 
@@ -92,12 +90,12 @@ fn find_plot_extents(lines: &HashMap<String, Line>) -> (Range<DateTime<Local>>, 
                 end_x = x;
             }
         }
-        for yerr in line.points.iter().map(|p| p.y_err) {
-            if yerr.0 <= start_y {
-                start_y = yerr.0;
+        for y in line.points.iter().map(|p| p.y) {
+            if y <= start_y {
+                start_y = y;
             }
-            if yerr.1 >= end_y {
-                end_y = yerr.1;
+            if y >= end_y {
+                end_y = y;
             }
         }
     }
@@ -163,18 +161,10 @@ pub fn plot(config: &PlotConfig) -> DateTime<Local> {
 
         // Draw line.
         chart
-            .draw_series(LineSeries::new(sorted_points, colour))
+            .draw_series(LineSeries::new(sorted_points, colour).point_size(2))
             .unwrap()
             .label(vm)
             .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colour));
-        // Draw error bars.
-        chart
-            .draw_series(
-                line.points
-                    .iter()
-                    .map(|p| ErrorBar::new_vertical(p.x, p.y_err.0, p.y, p.y_err.1, colour, 6)),
-            )
-            .unwrap();
     }
 
     // Draw on the legend.


### PR DESCRIPTION
We were questioning the correctness of the confidence intervals and agreed to simply remove them for now, since these benchmarks need only be rough. We will do a better job for the publication.

I've not spent much time polishing this, because I want to move on.

(I hadn't planned on handling crashing benchmarks, but since currently `List` fails, I was forced to. It was more involved that I expected)