### PR TITLE
Use a monotonic timer `os.monotonic`.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -27,7 +27,6 @@ setup() {
     # Build yklua with JIT support.
     git clone https://github.com/ykjit/yklua
     cd yklua
-    patch -p0 < $1/clua_gettime
     YK_BUILD_TYPE=release make -j $(nproc)
     mv src/lua src/yklua
     cd ..

--- a/patches/clua_gettime
+++ b/patches/clua_gettime
@@ -1,3 +1,5 @@
+diff --git src/loslib.c src/loslib.c
+index ad5a927..c19672d 100644
 --- src/loslib.c
 +++ src/loslib.c
 @@ -189,6 +189,20 @@ static int os_clock (lua_State *L) {
@@ -6,10 +8,10 @@
  
 +#include <sys/time.h>
 +#include "llimits.h"
-+static int os_gettime (lua_State *L) {
-+  struct timeval tv;
-+  if (gettimeofday(&tv, NULL) == 0) {
-+    double seconds = tv.tv_sec + tv.tv_usec / 1e6;
++static int os_monotonic (lua_State *L) {
++  struct timespec ts;
++  if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
++    double seconds = ts.tv_sec + ts.tv_nsec / 1e9;
 +    lua_pushnumber(L, cast_num(seconds));
 +    return 1;
 +  } else {
@@ -25,7 +27,7 @@
    {"execute",   os_execute},
    {"exit",      os_exit},
    {"getenv",    os_getenv},
-+  {"gettime",   os_gettime},
++  {"monotonic", os_monotonic},
    {"remove",    os_remove},
    {"rename",    os_rename},
    {"setlocale", os_setlocale},

--- a/suites/awfy/Lua/harness.lua
+++ b/suites/awfy/Lua/harness.lua
@@ -25,8 +25,7 @@
     os.clock() wraps the C clock() / CLOCKS_PER_SEC
     socket.gettime() wraps the POSIX gettimeofday() with a microsecond resolution
 ]]
-local ok, socket = pcall(require, 'socket')
-local gettime = os.gettime
+local gettime = os.monotonic
 
 local run = {} do
 


### PR DESCRIPTION
Needs https://github.com/ykjit/yklua/pull/120 to be merged first.

Unlike `gettime` this is definitely monotonic (even if it's not got quite the guarantees about time we would like). Also assume that yklua has been patched by default to have this function, and that we only need to patch "normal" CLua.