### PR TITLE
Ensure each lulpeg iteration does the same work.

### DIFF
--- a/suites/realworld/Lua/lulpeg.lua
+++ b/suites/realworld/Lua/lulpeg.lua
@@ -6,10 +6,15 @@ setmetatable(pg, {__index = require'benchmark'})
 lpeg = require "LuLPeg/lulpeg"
 lpeg.setmaxstack(10000)
 -- The file we want to parse.
-src = io.open("LuLPeg/lulpeg.lua","r"):read"*all"
+init_src = io.open("LuLPeg/lulpeg.lua","r"):read"*all"
 
 function pg:inner_benchmark_loop (inner_loops)
+    -- Note: the test file mutates the input string, so to ensure each
+    -- iteration does the same work, each iteration parses a copy of the
+    -- original input.
+    src = init_src
     dofile("LuLPeg/tests/luagrammar.lua") -- run the lua parser
+    assert(END == 89661)
     return true
 end
 


### PR DESCRIPTION
It mutates the input string:
https://github.com/pygy/LuLPeg/blob/f07f5be09d0461b1e83a8f811ca2c9cb79a69ab2/tests/luagrammar.lua#L212

Before:
```
Starting lulpeg benchmark ...
Success 89661
Success 89682
Success 89703
...
```

After:
```
Starting lulpeg benchmark ...
Success 89661
Success 89661
Success 89661
...
```