### PR TITLE
Add commit hashes to plots, make plots wider

### DIFF
--- a/reporter/src/plot.rs
+++ b/reporter/src/plot.rs
@@ -6,13 +6,14 @@ use plotters::prelude::*;
 use plotters::style::{FontDesc, FontFamily};
 use std::{collections::HashMap, ops::Range, path::PathBuf};
 
+#[derive(Clone)]
 pub struct Point {
     /// The X-value.
-    x: DateTime<Local>,
+    pub x: DateTime<Local>,
     /// The Y-value.
     ///
     /// None means that at least one benchmark crashed at this time.
-    y: Option<f64>,
+    pub y: Option<f64>,
 }
 
 impl Point {
@@ -38,6 +39,10 @@ impl Line {
     /// Add a point to the line.
     pub fn push(&mut self, point: Point) {
         self.points.push(point);
+    }
+
+    pub fn points(&self) -> &Vec<Point> {
+        &self.points
     }
 }
 

--- a/reporter/src/plot.rs
+++ b/reporter/src/plot.rs
@@ -142,7 +142,7 @@ fn find_plot_extents(
 /// Returns the last (rightmost) X value (if known).
 pub fn plot(config: &PlotConfig) -> Result<DateTime<Local>, ()> {
     if let Ok((x_extent, y_extent)) = find_plot_extents(&config.lines) {
-        let drawing = BitMapBackend::new(&config.output_path, (850, 600)).into_drawing_area();
+        let drawing = BitMapBackend::new(&config.output_path, (1200, 600)).into_drawing_area();
         drawing.fill(&WHITE).unwrap();
 
         let mut chart = ChartBuilder::on(&drawing)


### PR DESCRIPTION
Adds a section like this to the report:

<img width="772" height="423" alt="image" src="https://github.com/user-attachments/assets/cff7506c-f729-44c0-a244-8b1a6f09bd67" />

(Based on this, my change from the end of yesterday was indeed responsible for the slowdown)

Also make plots wider.