### PR TITLE
Lua has now removed `math.pow`.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@ cd suites/realworld/Lua
 
 cd hashids
 cp src/init.lua hashids.lua
+patch -p0 < ../hashids.patch
 cd ..
 
 cd heightmap

--- a/suites/realworld/Lua/hashids.patch
+++ b/suites/realworld/Lua/hashids.patch
@@ -1,0 +1,18 @@
+--- hashids.lua	Tue Apr  7 15:40:44 2026
++++ hashids.lua	Tue Apr  7 15:37:59 2026
+@@ -1,6 +1,5 @@
+ local ceil   = math.ceil
+ local floor  = math.floor
+-local pow    = math.pow
+ local substr = string.sub
+ local upcase = string.upper
+ local format = string.format
+@@ -46,7 +45,7 @@
+ 
+     for i=0, ilen do
+         local cpos = (alphabet:find(gcap(input, i), 1, true) - 1);
+-        number = number + cpos * pow(alen, (ilen - i - 1))
++        number = number + cpos * (alen ^ (ilen - i - 1))
+     end
+ 
+     return number;


### PR DESCRIPTION
This was deprecated in Lua 5.4, and removed in 5.5.