### PR TITLE
Update AWFY suite for csom.

### DIFF
--- a/haste_csom.toml
+++ b/haste_csom.toml
@@ -14,28 +14,28 @@ harness = "../../../haste_harness_som.sh"
 env = { "SOM_LIB" = "/path/to/CSOM/Smalltalk" }
 
 [suites.awfy.benchmarks.Richards]
-extra_args = ["10"]
+extra_args = ["100"]
 
 [suites.awfy.benchmarks.Bounce]
-extra_args = ["150"]
+extra_args = ["1500"]
 
 [suites.awfy.benchmarks.List]
 extra_args = ["1500"]
 
 [suites.awfy.benchmarks.Permute]
-extra_args = ["100"]
+extra_args = ["1000"]
 
 [suites.awfy.benchmarks.Queens]
-extra_args = ["100"]
+extra_args = ["1000"]
 
 [suites.awfy.benchmarks.Towers]
-extra_args = ["60"]
+extra_args = ["600"]
 
 [suites.awfy.benchmarks.Storage]
-extra_args = ["100"]
+extra_args = ["1000"]
 
 [suites.awfy.benchmarks.Sieve]
-extra_args = ["300"]
+extra_args = ["3000"]
 
 
 # --- Benchmark Failure Explanations ---
@@ -62,6 +62,6 @@ extra_args = ["300"]
 # [suites.awfy.benchmarks.Mandelbrot]
 # extra_args = ["5"]
 
-# Fails: ERROR: Benchmark failed with incorrect result
-# [suites.awfy.benchmarks.NBody]
-# extra_args = ["2"]
+
+[suites.awfy.benchmarks.NBody]
+extra_args = ["250000"]


### PR DESCRIPTION
Tested on https://github.com/ykjit/yksompp/commit/d682d019e636ca36d998b22d3046f0894e920fe4

yksompp benchmarks example:
```
haste diff 17 16
Datum17: yksompp-main
Datum16: yksompp-remove-fno-jump-tables

confidence level: 99%

 Benchmark          Datum17 (ms)  Datum16 (ms)  Ratio  Summary
 Towers/csom/600     134317 ±340    58869 ± 83   0.44  56.17% faster
 NBody/csom/250000    34066 ±155    34374 ±137   1.01  0.90% slower
 Storage/csom/1000    27532 ± 27    28002 ± 72   1.02  1.71% slower
 Queens/csom/1000     38320 ±241    38145 ±480   1.00  indistinguishable
 Sieve/csom/3000      46432 ±127    46604 ± 76   1.00  indistinguishable
 Richards/csom/100    96755 ±154    97197 ±623   1.00  indistinguishable
 List/csom/1500       21752 ±124    22024 ±430   1.01  indistinguishable
 Bounce/csom/1500     30526 ±478    31063 ±178   1.02  indistinguishable
 Permute/csom/1000    32151 ± 86    32730 ±751   1.02  indistinguishable
```