### PR TITLE
Fix classpath order in som harness.

### DIFF
--- a/haste_csom.toml
+++ b/haste_csom.toml
@@ -37,31 +37,21 @@ extra_args = ["1000"]
 [suites.awfy.benchmarks.Sieve]
 extra_args = ["3000"]
 
+[suites.awfy.benchmarks.CD]
+extra_args = ["250"]
 
-# --- Benchmark Failure Explanations ---
-# The benchmarks below currently fail due to compatibility gaps between 
-# the minimal "CSOM" VM and the "Are We Fast Yet" (AWFY) suite.
+[suites.awfy.benchmarks.DeltaBlue]
+extra_args = ["12000"]
 
-# Fails with: error: failed to run inner harness
-# [suites.awfy.benchmarks.CD]
-# extra_args = ["2"]
+[suites.awfy.benchmarks.Havlak]
+extra_args = ["1500"]
 
-# Fails with ERROR: Method forEach: not found in class Vector
-# [suites.awfy.benchmarks.DeltaBlue]
-# extra_args = ["12"]
+[suites.awfy.benchmarks.Json]
+extra_args = ["100"]
 
-# Fails with ERROR: Method ifNotNil:ifNil: not found in class Nil
-# [suites.awfy.benchmarks.Havlak]
-# extra_args = ["1"]
-
-# Fails with: ERROR: Lexer failed to read file. Run out of file reading buffer space.This is CSOM.
-# [suites.awfy.benchmarks.Json]
-# extra_args = ["1"]
-
-# Fails with: ERROR: Benchmark failed with incorrect result
-# [suites.awfy.benchmarks.Mandelbrot]
-# extra_args = ["5"]
-
+[suites.awfy.benchmarks.Mandelbrot]
+extra_args = ["500"]
 
 [suites.awfy.benchmarks.NBody]
 extra_args = ["250000"]
+

--- a/haste_harness_som.sh
+++ b/haste_harness_som.sh
@@ -16,12 +16,12 @@ inproc_iters=$1; shift
 # The parameter argument is optional.
 param=${1:-x}
 
-# Classpath: SOM_LIB (the SOM implementation's Smalltalk core library, set by
-# the user) plus the awfy SOM benchmark dir and each of its subdirs.
+# Classpath: awfy SOM benchmark dirs first, then SOM_LIB (the SOM
+# implementation's Smalltalk core library).
 SOM_DIR=../../awfy/SOM
 SUBDIRS="$SOM_DIR:$SOM_DIR/Core:$SOM_DIR/CD:$SOM_DIR/DeltaBlue:$SOM_DIR/Havlak:$SOM_DIR/Json:$SOM_DIR/NBody:$SOM_DIR/Richards"
 if [ -n "${SOM_LIB:-}" ]; then
-    CP="$SOM_LIB:$SUBDIRS"
+    CP="$SUBDIRS:$SOM_LIB"
 else
     CP="$SUBDIRS"
 fi


### PR DESCRIPTION
Fix a classpath ordering bug in haste_harness_som.sh where SOM_LIB was listed before the AWFY benchmark dirs, causing Smalltalk/Vector.som to shadow Core/Vector.som. 

Example of running awfy benchmarks with yksompp:
```
haste diff 31 29
Datum31: yksompp-main
Datum29: haste_yksompp_exp_called_flag

confidence level: 99%

 Benchmark             Datum31 (ms)  Datum29 (ms)  Ratio  Summary
 Towers/csom/600       58932 ±  113  24484 ±  401   0.42  58.45% faster
 CD/csom/250           98618 ±  291  63363 ±  944   0.64  35.75% faster
 Json/csom/100         27588 ±  370  23676 ±  119   0.86  14.18% faster
 Richards/csom/100     96886 ±  743  84546 ±  820   0.87  12.74% faster
 Havlak/csom/1500      68522 ±  694  61805 ± 2725   0.90  9.80% faster
 Permute/csom/1000     33106 ±  356  32415 ±   43   0.98  2.09% faster
 Storage/csom/1000     28027 ±   62  27443 ±   61   0.98  2.08% faster
 List/csom/1500        21881 ±  160  21538 ±   11   0.98  1.56% faster
 Mandelbrot/csom/500   22740 ±   39  22429 ±   14   0.99  1.37% faster
 NBody/csom/250000     34414 ±   63  33991 ±   44   0.99  1.23% faster
 Sieve/csom/3000       46634 ±  154  46245 ±    8   0.99  0.84% faster
 Queens/csom/1000      38245 ±  216  39429 ±  517   1.03  3.09% slower
 DeltaBlue/csom/12000   9750 ±  104  10335 ±   46   1.06  6.00% slower
 Bounce/csom/1500      30779 ±  315  30657 ±  673   1.00  indistinguishable
```